### PR TITLE
fix: prevent mobile to desktop version redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f-notifier",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Displays your Facebook notifications unread count.",
   "homepage": "https://dev.ligny.org/F-Notifier",
   "author": "Arnaud Ligny",

--- a/src/background.js
+++ b/src/background.js
@@ -140,9 +140,26 @@ function openFacebookHomeInTab(tab) {
   });
 }
 
+function rewriteUserAgentHeader(e) {
+  for (const header of e.requestHeaders) {
+    if (header.name.toLowerCase() === 'user-agent') {
+      // Prevent mobile to desktop version redirect
+      header.value = header.value.replace(/\sChrome\/[\d.]+/i, '$& Mobile');
+    }
+  }
+  return { requestHeaders: e.requestHeaders };
+}
+
 /**
  * Events
  */
+
+// Chrome request
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  rewriteUserAgentHeader,
+  { urls: [FETCH_URL] },
+  ['blocking', 'requestHeaders'],
+);
 
 // Chrome alarm
 chrome.alarms.create({delayInMinutes: 1, periodInMinutes: 1});

--- a/src/background.js
+++ b/src/background.js
@@ -140,14 +140,15 @@ function openFacebookHomeInTab(tab) {
   });
 }
 
-function rewriteUserAgentHeader(e) {
-  for (const header of e.requestHeaders) {
+function rewriteUserAgentHeader(event) {
+  for (const header of event.requestHeaders) {
     if (header.name.toLowerCase() === 'user-agent') {
       // Prevent mobile to desktop version redirect
-      header.value = header.value.replace(/\sChrome\/[\d.]+/i, '$& Mobile');
+      header.value = header.value.replace(/\schrome\/[\d.]+/i, '$& Mobile');
     }
   }
-  return { requestHeaders: e.requestHeaders };
+
+  return {requestHeaders: event.requestHeaders};
 }
 
 /**
@@ -157,7 +158,7 @@ function rewriteUserAgentHeader(e) {
 // Chrome request
 chrome.webRequest.onBeforeSendHeaders.addListener(
   rewriteUserAgentHeader,
-  { urls: [FETCH_URL] },
+  {urls: [FETCH_URL]},
   ['blocking', 'requestHeaders'],
 );
 

--- a/src/background.js
+++ b/src/background.js
@@ -144,7 +144,7 @@ function rewriteUserAgentHeader(event) {
   for (const header of event.requestHeaders) {
     if (header.name.toLowerCase() === 'user-agent') {
       // Prevent mobile to desktop version redirect
-      header.value = header.value.replace(/\schrome\/[\d.]+/i, '$& Mobile');
+      header.value = header.value.replace(/\schrome\/[\d.]+/i, '$& Mobile').replace(/;\s*rv:[\d.]+/i, '; Mobile$&');
     }
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_extName__",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "__MSG_extDescription__",
   "homepage_url": "https://dev.ligny.org/F-Notifier",
   "author": "Arnaud Ligny",
@@ -13,6 +13,8 @@
   "permissions": [
     "alarms",
     "tabs",
+    "webRequest",
+    "webRequestBlocking",
     "https://m.facebook.com/"
   ],
   "background": {


### PR DESCRIPTION
Unfortunately #62 issue has occurred again :( Facebook automatically redirects (HTTP 301 response) every https://m.facebook.com/home.php HTTP request to desktop version https://www.facebook.com/. The only solution is to rewrite User-Agent HTTP header to convince Facebook that HTTP request was sent from mobile browser.

PS: Rewriting User-Agent header simply in `window.fetch` function doesn't work in Chrome.